### PR TITLE
Adding trigger support to the plugin

### DIFF
--- a/api/models.py
+++ b/api/models.py
@@ -13,9 +13,9 @@ class Performer(db.Model):
     # one-to-one to Face
     face = db.relationship('Face', uselist=False)
     # when this was created
-    created_at = db.Column(db.DATETIME(timezone=True), nullable=False, default=datetime.datetime.now())
+    created_at = db.Column(db.DATETIME(timezone=True), nullable=False, default=datetime.datetime.utcnow())
     # when this was lasted updated.  Important for determining when to refresh data
-    updated_at = db.Column(db.DATETIME(timezone=True), nullable=False, default=datetime.datetime.now())
+    updated_at = db.Column(db.DATETIME(timezone=True), nullable=False, default=datetime.datetime.utcnow())
 
     def to_dict(self):
         return {
@@ -33,9 +33,9 @@ class Face(db.Model):
     # store the face encoding as a Pickle BLOB
     encoding = db.Column(db.PickleType, nullable=False)
     # when this was created
-    created_at = db.Column(db.DATETIME(timezone=True), nullable=False, default=datetime.datetime.now())
+    created_at = db.Column(db.DATETIME(timezone=True), nullable=False, default=datetime.datetime.utcnow())
     # when this was lasted updated.  Important for determining when to refresh data
-    updated_at = db.Column(db.DATETIME(timezone=True), nullable=False, default=datetime.datetime.now())
+    updated_at = db.Column(db.DATETIME(timezone=True), nullable=False, default=datetime.datetime.utcnow())
 
     def to_dict(self):
         return {

--- a/api/mutations.py
+++ b/api/mutations.py
@@ -1,5 +1,6 @@
-import datetime
-import logging
+from . import app
+from datetime import datetime
+import pytz
 import requests
 import tempfile
 import traceback
@@ -12,11 +13,10 @@ import face_recognition
 from PIL import UnidentifiedImageError
 import pickle
 
-
 @convert_kwargs_to_snake_case
 def create_performer_resolver(obj, info, stash_id):
     try:
-        now = datetime.datetime.now()
+        now = datetime.utcnow()
         performer = Performer(
             stash_id=stash_id, created_at=now, updated_at=now
         )
@@ -36,53 +36,68 @@ def create_performer_resolver(obj, info, stash_id):
 
 
 @convert_kwargs_to_snake_case
-def update_performer_resolver(obj, info, stash_id, image_path):
+def update_performer_resolver(obj, info, stash_id, image_path, updated_at):
     try:
-        now = datetime.datetime.now()
-        performer = Performer.query.get(stash_id)
-        if performer:
-            performer.updated_at = now
+        app.logger.debug(f"update_performer_resolver {stash_id}")
+        face_performer = Performer.query.get(stash_id)
+        if not face_performer:
+            # create the performer since one doesn't exist
+            create_performer_resolver(obj, info, stash_id)
+            face_performer = Performer.query.get(stash_id)
+
+        # check if we need to bother updating the performer
+        # The face_performer was loaded from the DB, which we assume is in UTC.  Gross.  We just set the timezone
+        # to UTC so we can run the compare.
+        # The timezone provided by Stash is in ISO format with a non UTC timestamp.  Convert that timestamp to UTC.
+        # If the stash performer was updated more recently than the face perfomer, then go ahead and recompute the face.
+        if datetime.fromisoformat(updated_at).astimezone(pytz.utc) > face_performer.updated_at.replace(tzinfo=pytz.utc):
+            # Load the image and get any faces
+            app.logger.info("Starting facial recognition on " + image_path)
+            tmp_img = tempfile.NamedTemporaryFile(delete=True)
+            try:
+                # Fetch the image and save to a temp file
+                tmp_img.write(requests.get(
+                    image_path,
+                    # TODO - load the API key from config
+                    headers={'ApiKey': "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1aWQiOiJ0YWNvIiwiaWF0IjoxNjUwMzc4MzA3LCJzdWIiOiJBUElLZXkifQ.TOFuBYbUAeHes4SRIiKiF4P6BQWhg0VeXVcwyo3X7F0"}
+                ).content)
+                app.logger.debug(f"Wrote Image to temp file: {tmp_img.name}")
+
+                # find faces in the image
+                performer_image = face_recognition.load_image_file(tmp_img.name)
+                performer_face_encodings = face_recognition.face_encodings(performer_image)
+
+                # dump to pickle for storage
+                if len(performer_face_encodings) == 0:
+                    # clear out the existing face if it exists
+                    if face_performer.face:
+                        app.logger.info(f"Performer {face_performer.stash_id} has no face, clearing old face value {face_performer.face_id}")
+                        face_performer.face_id = None
+                        face_performer.face = None
+                elif len(performer_face_encodings) == 1:
+                    face_performer.face = face_performer.face if face_performer.face else Face()
+                    face_performer.face.encoding = pickle.dumps(performer_face_encodings[0])
+                else:
+                    # Too many faces found.  Not storing them at all.
+                    app.logger.warning(f"Found unexpected number of encodings({len(performer_face_encodings)}) for {stash_id}")
+
+                app.logger.debug(f"Saved pickle for {stash_id}")
+            except (FileNotFoundError, UnidentifiedImageError) as err:
+                app.logger.warning(f"Could not load image for facial recognition: {image_path} \n{err}")
+            finally:
+                tmp_img.close()
         else:
-            # TODO - should we call create performer instead?
-            performer = Performer(
-                stash_id=stash_id, created_at=now, updated_at=now
-            )
+            # This is for the case were we are just updating perfomers in bulk.  No reason to reprocess their faces.
+            app.logger.info(f"Skipping facial recoginition on {face_performer.stash_id}, updated recently")
 
-        # Load the image and get any faces
-        logging.info("Starting facial recognition on " + image_path)
+        # set the updated timestamp
+        face_performer.updated_at = datetime.utcnow()
 
-        tmp_img = tempfile.NamedTemporaryFile(delete=True)
-        try:
-            # Fetch the image and save to a temp file
-            tmp_img.write(requests.get(
-                image_path,
-                # TODO - load the API key from config
-                headers={'ApiKey': "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1aWQiOiJ0YWNvIiwiaWF0IjoxNjUwMzc4MzA3LCJzdWIiOiJBUElLZXkifQ.TOFuBYbUAeHes4SRIiKiF4P6BQWhg0VeXVcwyo3X7F0"}
-            ).content)
-            logging.debug(f"Wrote Image to temp file: {tmp_img.name}")
-
-            # find faces in the image
-            performer_image = face_recognition.load_image_file(tmp_img.name)
-            performer_face_encodings = face_recognition.face_encodings(performer_image)
-
-            # dump to pickle for storage
-            if len(performer_face_encodings) > 0:
-                performer.face = Face()
-                performer.face.encoding = pickle.dumps(performer_face_encodings[0])
-            else:
-                logging.warning(f"Found unexpected number of encodings({len(performer_face_encodings)}) for {stash_id}")
-
-            logging.debug(f"Saved pickle for {stash_id}")
-        except (FileNotFoundError, UnidentifiedImageError) as err:
-            logging.warning(f"Could not load image for facial recognition: {image_path} \n{err}")
-        finally:
-            tmp_img.close()
-
-        db.session.add(performer)
+        db.session.add(face_performer)
         db.session.commit()
         payload = {
             "success": True,
-            "performer": performer.to_dict()
+            "performer": face_performer.to_dict()
         }
     except AttributeError as err:
         traceback.print_exc()
@@ -91,4 +106,5 @@ def update_performer_resolver(obj, info, stash_id, image_path):
             "errors": [f"item matching id {stash_id} not found: {err}"]
         }
 
+    app.logger.debug(f"Saved Performer: {payload}")
     return payload

--- a/api/queries.py
+++ b/api/queries.py
@@ -1,3 +1,4 @@
+from . import app
 from .models import Performer, Face
 from ariadne import convert_kwargs_to_snake_case
 import logging
@@ -5,9 +6,9 @@ import logging
 
 def listPerformers_resolver(obj, info):
     try:
-        logging.debug("listPerformers_resolver")
+        app.logger.debug("listPerformers_resolver")
         performers = [performer.to_dict() for performer in Performer.query.all()]
-        logging.info(f"Found {len(performers)} performers")
+        app.logger.info(f"Found {len(performers)} performers")
         payload = {
             "success": True,
             "performer": performers
@@ -24,7 +25,7 @@ def listPerformers_resolver(obj, info):
 def getPerformer_resolver(obj, info, stash_id):
     try:
         performer = Performer.query.get(stash_id)
-        logging.debug(f'performer: {performer.to_dict()}')
+        app.logger.debug(f'performer: {performer.to_dict()}')
         payload = {
             "success": True,
             "performer": performer.to_dict()

--- a/facestash.py
+++ b/facestash.py
@@ -5,6 +5,7 @@ from ariadne.constants import PLAYGROUND_HTML
 from flask import request, jsonify
 from api.queries import listPerformers_resolver, getPerformer_resolver
 from api.mutations import create_performer_resolver, update_performer_resolver
+import os
 
 # Configure the resolvers
 query = ObjectType("Query")
@@ -38,3 +39,10 @@ def graphql_server():
     )
     status_code = 200 if success else 400
     return jsonify(result), status_code
+
+
+@app.before_first_request
+def before_first_request():
+    logger_level = os.environ.get("LOGLEVEL", "INFO")
+    app.logger.warning(f"Setting logger level to {logger_level}")
+    app.logger.setLevel(logger_level)

--- a/plugins/facestash/facestash.yml
+++ b/plugins/facestash/facestash.yml
@@ -9,4 +9,12 @@ tasks:
   - name: Generate Performers
     description: Sends all the performers over to FaceStash for recognition.  This is meant for an initial load.  Additions and updates to performers will be processed automatically.
     defaultArgs:
-      mode: gen
+      mode: generate_performers
+hooks:
+  - name: Performer updates
+    description: When a performer is updated, send it over to facestash for processing
+    triggeredBy:
+      - Performer.Create.Post
+      - Performer.Update.Post
+    defaultArgs:
+      mode: update_performer

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ requests~=2.26.0
 gql~=3.2.0
 sqlalchemy-migrate
 Pillow~=9.1.0
+pytz

--- a/schema.graphql
+++ b/schema.graphql
@@ -36,5 +36,5 @@ type Query {
 
 type Mutation {
     createPerformer(stash_id: String!): PerformerResult!
-    updatePerformer(stash_id: String!, image_path: String!): PerformerResult!
+    updatePerformer(stash_id: String!, image_path: String!, updated_at: String!): PerformerResult!
 }


### PR DESCRIPTION
updatePerformer now requires an updated date.  That way we can avoid reprocessing performers that have already been processed.
Adding pytz as a requirement
Updated logging to use the Flask logger
Update Performer now uses the Create Performer function
Fixed a bunch of timezone stuff
Added validation/warning for the expected number of face encodings that get generated
Added the plugin triggers for performer create and update
Some refactoring of the plugin to since it serves both the trigger and the task now.